### PR TITLE
CC26X2R1 support and misc setup.py fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ ENV/
 
 # debug logs
 *.log
+
+# macOS stuff
+.DS_Store
+._.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     author_email="sanyatuning@gmail.com",
     license="GPL-3.0",
     packages=find_packages(exclude=["*.tests"]),
-    install_requires=["serial", "pyserial-asyncio", "zigpy-homeassistant>=0.10.0"],
+    install_requires=["pyserial-asyncio", "zigpy-homeassistant>=0.10.0"],
     tests_require=["pytest"],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     license="GPL-3.0",
     packages=find_packages(exclude=["*.tests"]),
     install_requires=["pyserial-asyncio", "zigpy-homeassistant>=0.10.0"],
-    tests_require=["pytest"],
+    tests_require=["pytest", "zhaquirks"],
 )

--- a/zigpy_cc/const.py
+++ b/zigpy_cc/const.py
@@ -1,4 +1,6 @@
-class ResetType:
+import enum
+
+class ResetType(enum.IntEnum):
     HARD = 0
     SOFT = 1
 
@@ -7,7 +9,7 @@ class System:
     resetType = ResetType
 
 
-class DeviceLogicalType:
+class DeviceLogicalType(enum.IntEnum):
     COORDINATOR = 0
     ROUTER = 1
     ENDDEVICE = 2
@@ -23,7 +25,7 @@ class ZDO:
     deviceLogicalType = DeviceLogicalType
 
 
-class networkLatencyReq:
+class networkLatencyReq(enum.IntEnum):
     NO_LATENCY_REQS = 0
     FAST_BEACONS = 1
     SLOW_BEACONS = 2

--- a/zigpy_cc/zigbee/start_znp.py
+++ b/zigpy_cc/zigbee/start_znp.py
@@ -6,6 +6,7 @@ from zigpy.zcl.clusters.security import IasZone
 from zigpy_cc.api import API
 from zigpy_cc.const import Constants
 from zigpy_cc.types import NetworkOptions, Subsystem, ZnpVersion, CommandType
+from zigpy_cc.exception import CommandError
 from zigpy_cc.zigbee.backup import Restore
 from zigpy_cc.zigbee.common import Common
 from zigpy_cc.zigbee.utils import getChannelMask
@@ -203,7 +204,7 @@ async def start_znp(znp: API, version, options: NetworkOptions, backupPath=""):
     try:
         await validate_item(znp, Items.znpHasConfigured(version), "hasConfigured")
         hasConfigured = True
-    except AssertionError:
+    except (AssertionError, CommandError):
         hasConfigured = False
 
     if backupPath and os.path.exists(backupPath) and not hasConfigured:


### PR DESCRIPTION
I had to make a few dependency changes to the `setup.py` file to get everything running and handle `CommandError` during `start_znp` to form the network with my CC26X2R1.